### PR TITLE
Close #33

### DIFF
--- a/cde-lists.md
+++ b/cde-lists.md
@@ -9,3 +9,4 @@
 4. [Integer Value Examples](#tab-example-int)
 5. [Floating Point Value Examples](#tab-example-flt)
 6. [Failing Examples](#tab-example-bad)
+7. [Serializations of integer number 1](#tbl-ser-1)

--- a/draft-ietf-cbor-cde.md
+++ b/draft-ietf-cbor-cde.md
@@ -770,8 +770,8 @@ Notes:
   The purpose of the restatement is to aid the work of implementers,
   not to redefine anything.
 
-  Preferred Serialization Encoders and Decoders as well as CDE
-  Encoders and Decoders have certain properties that are expressed
+  Preferred Serialization Encoders as well as CDE
+  Encoders and CDE-Checking Decoders have certain properties that are expressed
   using {{RFC2119}} keywords in this appendix.
 
 * Duplicate map keys are never valid in CBOR at all (see
@@ -803,8 +803,8 @@ Notes:
   requirements, such as requiring rejection of non-conforming inputs.
 
   If a generic decoder needs to be used that does not "support" CDE, a
-  simple (but somewhat clumsy) way to check for proper CDE encoding is
-  to re-encode the decoded data and check for bit-to-bit equality with
+  simple (but somewhat clumsy) way to check its input for proper CDE encoding is
+  to re-encode the decoded data with CDE and check for bit-to-bit equality with
   the original input.
 
 ## Preferred Serialization {#ps}
@@ -861,9 +861,8 @@ item, which follows the 3-bit field for the major type.
      and the shortest format.
      This trimming is performed only (preserves the value only) if all the
      rightmost bits removed are zero.
-     (This will always represent a double or single quiet NaN with a zero
-     NaN payload in a half-precision quiet NaN.)
-
+     (This means that a double or single quiet NaN that has a zero
+     NaN payload will always be represented in a half-precision quiet NaN.)
 
 1. If tags 2 and 3 are supported, the following apply:
 
@@ -876,19 +875,21 @@ item, which follows the 3-bit field for the major type.
    (This also applies to the use of tags 2 and 3 within other tags,
    such as 4 or 5.)
 
-### Preferred Serialization Decoders {#psd}
+### Decoders and Preferred Serialization {#psd}
 
 There are no special requirements that CBOR decoders need to meet to
-be a Preferred Serialization Decoder.
-Partial decoder implementations need to pay attention to at least the
+be what could be called a "Preferred Serialization Decoder".
+
+Partial decoder implementations that want to accept at least Preferred
+Serialization need to pay attention to at least the
 following requirements:
 
 1. Decoders MUST accept shortest-form encoded arguments (see {{Section
    3 of RFC8949@-cbor}}).
 
-1. If arrays or maps are supported, definite-length arrays or maps MUST be accepted.
+1. {:#arraymap-indef} If arrays or maps are supported, both definite-length and indefinite-length arrays or maps MUST be accepted.
 
-1. If text or byte strings are supported, definite-length text or byte
+1. {:#string-indef} If text or byte strings are supported, both definite-length and indefinite-length text or byte
    strings MUST be accepted.
 
 1. If floating-point numbers are supported, the following apply:
@@ -927,16 +928,26 @@ Preferred Serialization Encoder requirements, with the following additions:
 1. If text or byte strings are emitted, they MUST use definite-length
    encoding (never indefinite-length).
 
-### Basic Serialization Decoders {#bsd}
+### Decoders and Basic Serialization {#bsd}
 
-The Basic Serialization Decoder requirements are identical to the
-Preferred Serialization Decoder requirements.
+There are no special requirements that CBOR decoders need to meet to
+be what could be called a "Basic Serialization Decoder".
+
+Partial decoder implementations that want to accept at least Basic
+Serialization need to pay attention to the requirements for partial
+decoder implementations that accept Preferred Serialization, with the
+following relaxations from the items {{<arraymap-indef}} and {{<string-indef}} of {{psd}}:
+
+1. If arrays or maps are supported, definite-length arrays or maps MUST be accepted.
+
+1. If text or byte strings are supported, definite-length text or byte
+   strings MUST be accepted.
 
 ## CDE
 
 ### CDE Encoders
 
-1. CDE encoders MUST only emit CBOR fulfilling the basic
+1. CDE encoders MUST only emit CBOR that fulfills the basic
    serialization rules ({{bse}}).
 
 1. CDE encoders MUST sort maps by the CBOR representation of the map
@@ -960,18 +971,19 @@ Preferred Serialization Decoder requirements.
 The term "CDE-checking Decoder" is a shorthand for a CBOR decoder that
 advertises _supporting_ CDE (see the start of this appendix).
 
-1. CDE-checking decoders MUST follow the rules for preferred (and thus basic)
-   serialization decoders ({{psd}}).
+1. CDE-checking decoders MUST follow the rules for decoders that
+   accept Basic Serialization ({{bsd}}) and MUST check the input for
+   keeping the Basic Serialization constraints.
 
 1. CDE-checking decoders MUST check for ordering map keys and for basic
    validity of the CBOR encoding (see {{Section 5.3.1 of
    RFC8949@-cbor}}, which includes a check against duplicate map keys
    and invalid UTF-8).
 
-   To be called a CDE-checking decoder, it MUST NOT present to the application
-   a decoded data item that fails one of these checks (except maybe via
-   special diagnostic channels with no potential for confusion with a
-   correctly CDE-decoded data item).
+To be called a CDE-checking decoder, it MUST NOT present to the application
+a decoded data item that fails one of these checks (except maybe via
+special diagnostic channels with no potential for confusion with a
+correctly CDE-decoded data item).
 
 # Encoding Examples {#examples}
 

--- a/draft-ietf-cbor-cde.md
+++ b/draft-ietf-cbor-cde.md
@@ -374,7 +374,8 @@ Basing the definition of both CDE and ALDR rules on the
 generic data model of CBOR also means that there is no effect on the
 Concise Data Definition Language (CDDL)
 {{-cddl}}, except where the data description is documenting specific
-encoding decisions for byte strings that carry embedded CBOR {{cddl-support}}.
+encoding decisions for byte strings that carry embedded CBOR (see
+{{cddl-support}}).
 
 ## Additional CDE Constraint from Basic Serialization
 

--- a/draft-ietf-cbor-cde.md
+++ b/draft-ietf-cbor-cde.md
@@ -771,7 +771,7 @@ Notes:
   not to redefine anything.
 
   Preferred Serialization Encoders as well as CDE
-  Encoders and CDE-Checking Decoders have certain properties that are expressed
+  Encoders and CDE-checking Decoders have certain properties that are expressed
   using {{RFC2119}} keywords in this appendix.
 
 * Duplicate map keys are never valid in CBOR at all (see

--- a/draft-ietf-cbor-cde.md
+++ b/draft-ietf-cbor-cde.md
@@ -13,8 +13,8 @@ area: "Applications and Real-Time"
 workgroup: CBOR
 keyword:
 
-v3xml2rfc:
-  table_borders: light
+# v3xml2rfc:
+#  table_borders: light
 
 venue:
   group: "Concise Binary Object Representation Maintenance and Extensions (CBOR)"
@@ -213,6 +213,8 @@ discussed in {{Section 2 of -det}}.
 
 {{tab-constraints}} summarizes the increasingly restrictive sets of
 encoding choices that have been given names in this section.
+
+<?v3xml2rfc table_borders="full" ?>
 
 {: #tab-constraints title="Constraints on the Serialization of CBOR"}
 | Set of Encoding Choices | Most Important Constraint | Applications |
@@ -486,6 +488,8 @@ This document requests IANA to register the contents of
 "{{cddl-control-operators (CDDL Control Operators)<IANA.cddl}}" of the
 {{IANA.cddl}} registry group:
 
+<?v3xml2rfc table_borders="light" ?>
+
 | Name      | Reference |
 | .cde      | \[RFCXXXX] |
 | .cdeseq   | \[RFCXXXX] |
@@ -499,6 +503,8 @@ This document requests IANA to register the contents of
 This appendix is informative.
 
 For a good understanding of this document, it is helpful to understand the difference between an information model, a data model and serialization.
+
+<?v3xml2rfc table_borders="full" ?>
 
 |                   | Abstraction Level                                            | Example                                              | Standards | Implementation Representation                                       |
 | Information Model | Top level; conceptual                                        | The temperature of something                         |           |                                                                     |

--- a/draft-ietf-cbor-cde.md
+++ b/draft-ietf-cbor-cde.md
@@ -281,7 +281,8 @@ types 0/1 in a seamless way.
 {{Section 4.2.2 of RFC8949@-cbor}} recommends handling this transition the same
 way as with the transition between different integer representation
 lengths in the basic generic data model, i.e., by mandating the
-Preferred Serialization for all integers ({{Section 3.4.3 of RFC8949@-cbor}}).
+Preferred Serialization for all integers ({{Section 3.4.3 of
+RFC8949@-cbor}}; see also {{exa-int}} and {{exa-pref}}).
 
 {: group="1"}
 1. By adopting the encoding constraints from Preferred Serialization,
@@ -983,6 +984,41 @@ interested in the file `example-table-input.csv` in the github
 repository `cbor-wg/draft-ietf-cbor-cde`.
 
 {::include example-tables.md}
+
+# Examples for Preferred Serialization of Integers {#exa-pref}
+
+This appendix looks at the set of encoded CBOR data items that
+represent the integer number `1`.
+Preferred Serialization chooses one of them (`0x01`), which is then
+always used to encode the number.
+The CDE encoding constraints include those of preferred serialization.
+A CDE-checking decoder checks that no other serialization is being
+used in the encoded data item being decoded.
+
+<?v3xml2rfc table_borders="full" ?>
+
+| Serialization of integer number 1                    | Preferred?                             |
+| 0x01                                                 | yes (shortest mt0)                     |
+| 0x1801, 0x190001, 0x1a00000001, 0x1b0000000000000001 | no (mt0, but not shortest argument)    |
+| 0xc24101                                             | no (could use mt0)                     |
+| 0xc2420001, 0xc243000001, etc.                       | no (could use mt0, uses leading zeros) |
+| 0xc25f41004101ff, and similar                        | no (could use mt0, uses leading zeros) |
+{: #tbl-ser-1 title="Serializations of integer number 1"}
+
+For the integer number 100000000000000000000 (1 with 20 decimal
+zeros), the only *basic* serialization is:
+
+~~~
+C2                       # tag(2)
+   49                    # bytes(9)
+      056BC75E2D63100000 #
+~~~
+
+(Note that, in addition to this serialization, there are multiple
+serializations that would also count as *preferred* serializations, as
+the preferred serialization constraint by itself does not exclude
+indefinite length encoding of the byte string that is the content of
+tag 2.)
 
 {::include-all cde-lists.md}
 

--- a/example-table-input.csv
+++ b/example-table-input.csv
@@ -65,10 +65,11 @@ flt,1.1754943508222878e-38,fb3810000000000001,"-""-"
 flt,3.4028234663852882e+38,fb47efffffdfffffff,Adjacent to largest 32-bit float
 flt,3.402823466385289e+38,fb47efffffe0000001,"-""-"
 bad,"{""b"":0,""a"":1}",a2616200616101,Incorrect map key ordering
+bad,"[4, 5]",98020405,Array length not in preferred encoding
 bad,255,1900ff,Integer not in preferred encoding
 bad,-18446744073709551617,c34a00010000000000000000,Bigint with leading zero bytes
-bad,10.5,fa41280000,Not in shortest encoding
-bad,NaN,fa7fc00000,Not in shortest encoding
+bad,10.5,fa41280000,Not in preferred encoding
+bad,NaN,fa7fc00000,Not in preferred encoding
 bad,65536,c243010000,Integer value too small for bigint
 bad,"(_ h'01', h'0203')",5f4101420203ff,Indefinite length encoding
 bad,"",f818,Simple values 24..31 not in use

--- a/example-tables.md
+++ b/example-tables.md
@@ -1,4 +1,4 @@
-## Integer Value Examples
+## Integer Value Examples {#exa-int}
 
 <?v3xml2rfc table_borders="light" ?>
 
@@ -27,7 +27,7 @@
 | -18446744073709551617 | c349010000000000000000 | Largest negative bigint |
 {: #tab-example-int title="Integer Value Examples"}
 
-## Floating Point Value Examples
+## Floating Point Value Examples {#exa-flt}
 
 <?v3xml2rfc table_borders="light" ?>
 
@@ -78,7 +78,7 @@
 | 3.402823466385289e+38 | fb47efffffe0000001 | -"- |
 {: #tab-example-flt title="Floating Point Value Examples"}
 
-## Failing Examples
+## Failing Examples {#exa-bad}
 
 <?v3xml2rfc table_borders="light" ?>
 

--- a/example-tables.md
+++ b/example-tables.md
@@ -1,5 +1,7 @@
 ## Integer Value Examples
 
+<?v3xml2rfc table_borders="light" ?>
+
 | EDN | CBOR (hex) | Comment |
 | 0 | 00 | Smallest unsigned immediate int |
 | -1 | 20 | Largest negative immediate int |
@@ -26,6 +28,8 @@
 {: #tab-example-int title="Integer Value Examples"}
 
 ## Floating Point Value Examples
+
+<?v3xml2rfc table_borders="light" ?>
 
 | EDN | CBOR (hex) | Comment |
 | 0.0 | f90000 | Zero |
@@ -75,6 +79,8 @@
 {: #tab-example-flt title="Floating Point Value Examples"}
 
 ## Failing Examples
+
+<?v3xml2rfc table_borders="light" ?>
 
 | EDN | CBOR (hex) | Comment |
 | {"b":0,"a":1} | a2616200616101 | Incorrect map key ordering |

--- a/example-tables.md
+++ b/example-tables.md
@@ -78,10 +78,11 @@
 
 | EDN | CBOR (hex) | Comment |
 | {"b":0,"a":1} | a2616200616101 | Incorrect map key ordering |
+| [4, 5] | 98020405 | Array length not in preferred encoding |
 | 255 | 1900ff | Integer not in preferred encoding |
 | -18446744073709551617 | c34a00010000000000000000 | Bigint with leading zero bytes |
-| 10.5 | fa41280000 | Not in shortest encoding |
-| NaN | fa7fc00000 | Not in shortest encoding |
+| 10.5 | fa41280000 | Not in preferred encoding |
+| NaN | fa7fc00000 | Not in preferred encoding |
 | 65536 | c243010000 | Integer value too small for bigint |
 | (_ h'01', h'0203') | 5f4101420203ff | Indefinite length encoding |
 | (Not CBOR) | f818 | Simple values 24..31 not in use |

--- a/generate-tables.rb
+++ b/generate-tables.rb
@@ -70,6 +70,8 @@ end
 typs.keys.each do |typ|
   puts "## #{typs[typ]}"
   puts
+  puts '<?v3xml2rfc table_borders="light" ?>'
+  puts
   puts tables[typ]
   puts %{{: #tab-example-#{typ} title="#{typs[typ]}"}}
   puts

--- a/generate-tables.rb
+++ b/generate-tables.rb
@@ -68,7 +68,7 @@ csv.each do |row|
 end
 
 typs.keys.each do |typ|
-  puts "## #{typs[typ]}"
+  puts "## #{typs[typ]} {#exa-#{typ}}"
   puts
   puts '<?v3xml2rfc table_borders="light" ?>'
   puts


### PR DESCRIPTION
Section 3: Don't try to hide the fact that most clarifications in Section 3 are about Preferred Serialization; explain why these are needed specifically for CDE.

Attendant editorial fixes:

* s/CDE decoder/CDE-checking decoder/
* Always capitalize ___ed Serialization
* reduce use of "shortest" in examples when we mean preferred